### PR TITLE
Do not use version generation based on debian changelog.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,12 +27,6 @@ import re
 from setuptools import setup
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
-try:
-    with open("%s/debian/changelog" % BASE_DIR, 'r') as f:
-        _version = re.findall(r"\(([^)]*)\)", f.readline())[0]
-        print("Found version %s in debian/changelog" % _version)
-except Exception:
-    _version = "0.10.6.0"
 
 if "--without-tools" in sys.argv:
     sys.argv.remove("--without-tools")
@@ -64,7 +58,7 @@ else:
 
 setup(
     name="cocaine",
-    version=_version,
+    version="0.10.6.9",
     author="Anton Tyurin",
     author_email="noxiouz@yandex.ru",
     maintainer='Evgeny Safronov',


### PR DESCRIPTION
When package installs via pip, version of package are always evaluated to 0.10.6.0, because there are no debian changelog in the moment of installation. Or extract version from debian changelog, write it to file and distribute with pypi distribution.
