### PR TITLE
Refactoring over `cocaine.futures.Future` class.

### DIFF
--- a/cocaine/asio/service.py
+++ b/cocaine/asio/service.py
@@ -181,7 +181,7 @@ class AbstractService(object):
 
         try:
             if msg.id == message.RPC_CHUNK:
-                self._subscribers[msg.session].callback(msgpack.unpackb(msg.data))
+                self._subscribers[msg.session].trigger(msgpack.unpackb(msg.data))
             elif msg.id == message.RPC_CHOKE:
                 future = self._subscribers.pop(msg.session, None)
                 assert future is not None, 'one of subscribers has suddenly disappeared'

--- a/cocaine/futures/chain.py
+++ b/cocaine/futures/chain.py
@@ -84,7 +84,7 @@ class PreparedFuture(Future):
         self._bound = False
         self._lock = threading.Lock()
 
-    def bind(self, callback, errorback=None, on_done=None):
+    def bind(self, callback, errorback=None):
         with self._lock:
             self._bound = True
 
@@ -128,7 +128,7 @@ class Deferred(Future):
         super(Deferred, self).__init__()
         self.unbind()
 
-    def bind(self, callback, errorback=None, on_done=None):
+    def bind(self, callback, errorback=None):
         self.callback = callback
         self.errorback = errorback
 
@@ -187,7 +187,7 @@ class GeneratorFutureMock(Future):
         self._currentFuture = None
         self._results = collections.deque(maxlen=1)
 
-    def bind(self, callback, errorback=None, on_done=None):
+    def bind(self, callback, errorback=None):
         self.callback = callback
         self.errorback = errorback
         self._advance()


### PR DESCRIPTION
- convenient naming
- states
- guard asserts
- thread safety
