### PR TITLE
fix: support both lowercase and camelcase headers' keys

### DIFF
--- a/cocaine/decorators/http.py
+++ b/cocaine/decorators/http.py
@@ -23,7 +23,7 @@ import msgpack
 import urlparse
 from tornado import escape
 
-from tornado.httputil import parse_body_arguments
+from tornado.httputil import parse_body_arguments, HTTPHeaders
 
 from _callablewrappers import proxy_factory
 
@@ -120,7 +120,7 @@ from tornado.httpserver import HTTPRequest, Cookie
 
 def _tornado_request_wrapper(data):
     method, uri, version, headers, body = msgpack.unpackb(data)
-    return HTTPRequest(method, uri, version, dict(headers), body)
+    return HTTPRequest(method, uri, version, HTTPHeaders(headers), body)
 
 
 def tornado_request_decorator(obj):


### PR DESCRIPTION
Solved a problem with the letter case of headers' keys. 

When I used httplib2 python library I noticed that Cocaine couldn't receive multipart body and my Flask application hadn't any uploaded files in request.files object. 

The cause of this problem was different letter case in headers and in tornado.wsgi.WSGIContainer.environ method which can process only camelcase headers. 

``` python
if "Content-Type" in request.headers:
            environ["CONTENT_TYPE"] = request.headers.pop("Content-Type")
```

I fixed the problem by using HTTPHeaders decorator object that extends built-in dict class. It maintains `Http-Header-Case` for all keys.
