### PR TITLE
Reconnect Locator on socket error

### DIFF
--- a/cocaine/asio/service.py
+++ b/cocaine/asio/service.py
@@ -449,7 +449,7 @@ class Service(AbstractService):
                 break
             except ServiceError as err:
                 raise LocatorResolveError(self.name, locator.address, err)
-            except (KeyError, AttributeError) as err:  # It means locator is disconnected.
+            except (KeyError, AttributeError, socket.error) as err:  # It means locator is disconnected.
                 log.warn("locator.resolve() throw an error: %s. %d attemp(s) left", err, attemps)
                 locator.disconnect()
                 log.debug("Disconnect locator")


### PR DESCRIPTION
Hi!

If some problem occures with cocaine-runtime and it is restarted by OS (the reason does not matters), the Locator Service socket becomes broken. So when trying to resolve any Service, Locator throws exceptions forever...

Some log examples:

```
Traceback (most recent call last):
   File "/opt/bioapp/bio_http_proxy/handlers.py", line 69, in run_service
    service = Service(cocaine_service_name)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 421, in __init__
    self.connect(host, port, blocking=True)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 45, in wrapper
    return strategy.init(func, blocking)(*args, **kwargs)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 55, in wrapper
    chunk = g.send(chunk)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 449, in connect
    yield self.connectThroughLocator(locator, timeout, blocking=blocking)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 45, in wrapper
    return strategy.init(func, blocking)(*args, **kwargs)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 55, in wrapper
    chunk = g.send(chunk)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 460, in connectThroughLocator
    endpoint, self.version, api = yield locator.resolve(self.name, timeout, blocking=blocking)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 354, in resolve
    (endpoint, version, api), = [chunk for chunk in self.perform_sync('resolve', name, timeout=timeout)]
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 292, in perform_sync
    data = sock.recv(4096)
 error: [Errno 54] Connection reset by peer
```

```
Traceback (most recent call last):
   File "/opt/bioapp/bio_http_proxy/handlers.py", line 69, in run_service
    service = Service(cocaine_service_name)
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 421, in __init__
    self.connect(host, port, blocking=True)
...
<The same lines...>
...
   File "/usr/local/Cellar/python/2.7.8/Frameworks/Python.framework/Versions/2.7/lib/python2.7/site-packages/cocaine/asio/service.py", line 288, in perform_sync
    sock.send(msgpack.dumps([self.api[method], self._session, args]))
 error: [Errno 32] Broken pipe
```

The patch fixes this bug.
