### PR TITLE
Dynamically use default values for host and port in Service methods.

### DIFF
--- a/cocaine/asio/service.py
+++ b/cocaine/asio/service.py
@@ -421,23 +421,22 @@ class Service(AbstractService):
                   If you don't want to create connection to the locator each time you create service, you can use
                   `connectThroughLocator` method, which is specially designed for that cases.
         """
-        host = host or self.host or LOCATOR_DEFAULT_HOST
-        port = port or self.port or LOCATOR_DEFAULT_PORT
         # Store endpoint here as Locator doesn't hold this info.
-        self.host = host
-        self.port = port
+        self.host = host or self.host or LOCATOR_DEFAULT_HOST
+        self.port = port or self.port or LOCATOR_DEFAULT_PORT
+
         # Is it good?
         self.locator_timeout = timeout
 
-        if (host, port) not in self._locator_cache:
+        if (self.host, self.port) not in self._locator_cache:
             locator = Locator()
-            self._locator_cache[(host, port)] = locator
+            self._locator_cache[(self.host, self.port)] = locator
         else:
-            locator = self._locator_cache[(host, port)]
+            locator = self._locator_cache[(self.host, self.port)]
 
         try:
             if not locator.isConnected():
-                yield locator.connect(host, port, timeout, blocking=blocking)
+                yield locator.connect(self.host, self.port, timeout, blocking=blocking)
             yield self.connectThroughLocator(locator, timeout, blocking=blocking)
         finally:
             pass

--- a/cocaine/asio/service.py
+++ b/cocaine/asio/service.py
@@ -397,8 +397,10 @@ class Service(AbstractService):
     """
     _locator_cache = {}
 
-    def __init__(self, name, blockingConnect=True, host=LOCATOR_DEFAULT_HOST, port=LOCATOR_DEFAULT_PORT):
+    def __init__(self, name, blockingConnect=True, host=None, port=None):
         super(Service, self).__init__(name)
+        host = host or LOCATOR_DEFAULT_HOST
+        port = port or LOCATOR_DEFAULT_PORT
         self.host = None
         self.port = None
 
@@ -409,7 +411,7 @@ class Service(AbstractService):
             self.connect(host, port, blocking=True)
 
     @strategy.coroutine
-    def connect(self, host=LOCATOR_DEFAULT_HOST, port=LOCATOR_DEFAULT_PORT, timeout=None, blocking=False):
+    def connect(self, host=None, port=None, timeout=None, blocking=False):
         """Connect to the service through locator and initialize its API.
 
         Before service is connected to its endpoint there is no any API (cause it's provided by locator). Any usage of
@@ -419,6 +421,8 @@ class Service(AbstractService):
                   If you don't want to create connection to the locator each time you create service, you can use
                   `connectThroughLocator` method, which is specially designed for that cases.
         """
+        host = host or self.host or LOCATOR_DEFAULT_HOST
+        port = port or self.port or LOCATOR_DEFAULT_PORT
         # Store endpoint here as Locator doesn't hold this info.
         self.host = host
         self.port = port


### PR DESCRIPTION
Now I can override DEFAULT_LOCATOR_HOST/LOCATOR_DEFAULT_PORT in runtime.