### PR TITLE
logs: TraceAdapter adds trace_id to extra

### DIFF
--- a/cocaine/detail/baseservice.py
+++ b/cocaine/detail/baseservice.py
@@ -42,7 +42,8 @@ from ..exceptions import DisconnectionError, ServiceConnectionError
 
 class TraceAdapter(logging.LoggerAdapter):
     def process(self, msg, kwargs):
-        return '%s\t%s' % (self.extra["traceid"], msg), kwargs
+        kwargs.setdefault("extra", {}).update(self.extra)
+        return msg, kwargs
 
 
 def weak_wrapper(weak_service, method_name, *args, **kwargs):
@@ -88,7 +89,7 @@ class BaseService(object):
         if self._connected:
             return
 
-        log = TraceAdapter(self.log, {"traceid": traceid}) if traceid else self.log
+        log = TraceAdapter(self.log, {"trace_id": traceid}) if traceid else self.log
 
         log.info("acquiring the connection lock")
         with (yield self._lock.acquire()):

--- a/cocaine/detail/service.py
+++ b/cocaine/detail/service.py
@@ -48,7 +48,7 @@ class Service(BaseService):
 
     @coroutine
     def connect(self, traceid=None):
-        log = TraceAdapter(self.log, {"traceid": traceid}) if traceid else self.log
+        log = TraceAdapter(self.log, {"trace_id": traceid}) if traceid else self.log
 
         log.debug("checking if service connected")
         if self._connected:


### PR DESCRIPTION
It allows to log trace_id via LoggerWithExtraInRecord as an attribute