### PR TITLE
logger: speedup Logger and add fallback logger to stderr

### DIFF
--- a/cocaine/detail/util.py
+++ b/cocaine/detail/util.py
@@ -28,12 +28,14 @@ import msgpack
 
 
 if sys.version_info[0] == 2:
+    msgpack_pack = msgpack.pack
     msgpack_packb = msgpack.packb
     msgpack_unpackb = msgpack.unpackb
     msgpack_unpacker = partial(msgpack.Unpacker, use_list=True)
 else:  # pragma: no cover
     # py3: msgpack by default unpacks strings as bytes.
     # Make it to unpack as strings for compatibility.
+    msgpack_pack = msgpack.pack
     msgpack_packb = msgpack.packb
     msgpack_unpackb = partial(msgpack.unpackb, encoding="utf8")
     msgpack_unpacker = partial(msgpack.Unpacker, encoding="utf8", use_list=True)


### PR DESCRIPTION
Avoid creating a new coroutine, future per message. Messages are put into a queue, if the queue is full, new messages will be logged via fallback mechanism until the queue gets free space.