### PR TITLE
TCP keep-alive for services

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+cocaine-framework-python (0.12.14.0) unstable; urgency=low
+
+  * [Service]: Activate TCP keep-alive for services.
+
+ -- Evgeny Safronov <division494@gmail.com>  Thu, 27 Jul 2017 19:42:03 +0300
+
 cocaine-framework-python (0.12.13.4) unstable; urgency=low
 
   * [Service]: bugfix: sessions are not notified that pipe is closed

--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ from setuptools import setup
 
 setup(
     name="cocaine",
-    version="0.12.13.4",
+    version="0.12.14.0",
     author="Anton Tyurin",
     author_email="noxiouz@yandex.ru",
     maintainer='Evgeny Safronov',


### PR DESCRIPTION
Consider `unicorn::lock` method used for master selection. If a node has completely lost network connectivity and becomes down a lock's owner will never know about it, because RST will not be delivered.

This patch activates TCP keep-alive option for services.

```bash
esafronov@5:~|⇒  sudo tshark -iany tcp port 57792
Capturing on 'any'
    1   0.000000 5.255.232.237 → 5.255.232.237 TCP 64 57910 → 57792 [SYN, ECN, CWR] Seq=0 Win=65535 Len=0 MSS=16344 WS=32 TSval=309292477 TSecr=0 SACK_PERM=1
    2   0.000008 5.255.232.237 → 5.255.232.237 TCP 64 [TCP Out-Of-Order] 57910 → 57792 [SYN, ECN, CWR] Seq=0 Win=65535 Len=0 MSS=16344 WS=32 TSval=309292477 TSecr=0 SACK_PERM=1
    3   0.000052 5.255.232.237 → 5.255.232.237 TCP 64 57792 → 57910 [SYN, ACK] Seq=0 Ack=1 Win=65535 Len=0 MSS=16344 WS=32 TSval=309292477 TSecr=309292477 SACK_PERM=1
    4   0.000053 5.255.232.237 → 5.255.232.237 TCP 64 [TCP Out-Of-Order] 57792 → 57910 [SYN, ACK] Seq=0 Ack=1 Win=65535 Len=0 MSS=16344 WS=32 TSval=309292477 TSecr=309292477 SACK_PERM=1
    5   0.000059 5.255.232.237 → 5.255.232.237 TCP 52 57910 → 57792 [ACK] Seq=1 Ack=1 Win=408288 Len=0 TSval=309292477 TSecr=309292477
    6   0.000060 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Dup ACK 5#1] 57910 → 57792 [ACK] Seq=1 Ack=1 Win=408288 Len=0 TSval=309292477 TSecr=309292477
    7   0.000068 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Window Update] 57792 → 57910 [ACK] Seq=1 Ack=1 Win=408288 Len=0 TSval=309292477 TSecr=309292477
    8   0.000069 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Dup ACK 3#1] 57792 → 57910 [ACK] Seq=1 Ack=1 Win=408288 Len=0 TSval=309292477 TSecr=309292477
    9   0.000784 5.255.232.237 → 5.255.232.237 TCP 79 57910 → 57792 [PSH, ACK] Seq=1 Ack=1 Win=408288 Len=27 TSval=309292477 TSecr=309292477
   10   0.000794 5.255.232.237 → 5.255.232.237 TCP 79 [TCP Retransmission] 57910 → 57792 [PSH, ACK] Seq=1 Ack=1 Win=408288 Len=27 TSval=309292477 TSecr=309292477
   11   0.000805 5.255.232.237 → 5.255.232.237 TCP 52 57792 → 57910 [ACK] Seq=1 Ack=28 Win=408256 Len=0 TSval=309292477 TSecr=309292477
   12   0.000807 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Dup ACK 11#1] 57792 → 57910 [ACK] Seq=1 Ack=28 Win=408256 Len=0 TSval=309292477 TSecr=309292477
   13   0.003020 5.255.232.237 → 5.255.232.237 TCP 176 57792 → 57910 [PSH, ACK] Seq=1 Ack=28 Win=408256 Len=124 TSval=309292480 TSecr=309292477
   14   0.003029 5.255.232.237 → 5.255.232.237 TCP 176 [TCP Retransmission] 57792 → 57910 [PSH, ACK] Seq=1 Ack=28 Win=408256 Len=124 TSval=309292480 TSecr=309292477
   15   0.003047 5.255.232.237 → 5.255.232.237 TCP 52 57910 → 57792 [ACK] Seq=28 Ack=125 Win=408160 Len=0 TSval=309292480 TSecr=309292480
   16   0.003050 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Dup ACK 15#1] 57910 → 57792 [ACK] Seq=28 Ack=125 Win=408160 Len=0 TSval=309292480 TSecr=309292480

   17   5.023751 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   18   5.023793 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   19   5.023831 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309297485 TSecr=309292480
   20   5.023837 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309297485 TSecr=309292480

   21  10.036563 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   22  10.036591 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   23  10.036614 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309302486 TSecr=309292480
   24  10.036618 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309302486 TSecr=309292480

   25  15.551082 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   26  15.551113 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   27  15.551137 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309307984 TSecr=309292480
   28  15.551140 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309307984 TSecr=309292480

   29  20.652546 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   30  20.652572 5.255.232.237 → 5.255.232.237 TCP 40 [TCP Keep-Alive] 57910 → 57792 [ACK] Seq=27 Ack=125 Win=408160 Len=0
   31  20.652596 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309313060 TSecr=309292480
   32  20.652599 5.255.232.237 → 5.255.232.237 TCP 52 [TCP Keep-Alive ACK] 57792 → 57910 [ACK] Seq=125 Ack=28 Win=408256 Len=0 TSval=309313060 TSecr=309292480
```

May not be the ideal solution. Feel free to suggest the better one.